### PR TITLE
Update instructions for Resistor Color

### DIFF
--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -4,16 +4,16 @@ Resistors have color coded bands, where each color maps to a number. The first 2
 
 These colors are encoded as follows:
 
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
 
 Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
 


### PR DESCRIPTION
Following issue [Instructions for Resistor Color are misleading #833](https://github.com/exercism/javascript/issues/833), I propose such change to the instructions...